### PR TITLE
Add draw functionality to GridCanvas

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -70,6 +70,13 @@ function App() {
                         style: { background: 'lightcoral' }
                     },
                     {
+                        column: { id: 'column_13' },
+                        draw: ({ctx, value, column, row}) => {
+                            ctx.fillStyle = 'red';
+                            ctx.fillRect(5, 5, Math.min(value / 20, column.width - 10), row.height - 10);
+                        }
+                    },
+                    {
                         row: { id: 5 },
                         column: { id: 'column_5' },
                         style: { borderLeft: { width: 3 }, borderTop: { width: 3 }, borderRight: { width: 3 } }

--- a/lib/src/fragments/GridCanvas.jsx
+++ b/lib/src/fragments/GridCanvas.jsx
@@ -141,6 +141,9 @@ export default function GridCanvas({
                     ctx.fillStyle = style.background || 'white';
                     ctx.fillRect(0, 0, cellWidth, cellHeight);
 
+                    if (cell.draw)
+                        cell.draw(ctx);
+
                     if (style.highlight) {
                         ctx.fillStyle = style.highlight;
                         ctx.fillRect(0, 0, cellWidth, cellHeight);

--- a/lib/src/utils/FormatResolverRules.js
+++ b/lib/src/utils/FormatResolverRules.js
@@ -69,6 +69,8 @@ export default class FormatResolverRules {
             entry.value = typeof rule.value === 'function' ? rule.value : () => rule.value;
         if ('edit' in rule)
             entry.edit = rule.edit;
+        if ('draw' in rule)
+            entry.draw = rule.draw;
 
         function addRowRule(lookup, key) {
             if (!lookup.has(key))
@@ -133,6 +135,7 @@ export default class FormatResolverRules {
 
         let context = { data, rows, columns, row, column };
         let style = {};
+        let draw = undefined;
 
         if (edition.hasKeyValue(row.key, column.key))
             context = { ...context, newValue: edition.getKeyValue(row.key, column.key) };
@@ -147,13 +150,19 @@ export default class FormatResolverRules {
                 style = { ...style, ...indexBorders(rule.style(context), rule.index) };
             if ('edit' in rule)
                 context = { ...context, edit: rule.edit };
+            if ('draw' in rule)
+            {
+                const currentContext = context;
+                draw = (ctx) => rule.draw({ ...currentContext, ctx });
+            }
         }
 
         // TODO: return also the text
         return {
             value: context.value,
             style: style,
-            edit: context.edit
+            edit: context.edit,
+            draw: draw
         };
     }
 }


### PR DESCRIPTION
This pull request adds a new feature to the GridCanvas component that allows for custom drawing in individual cells. The draw functionality is implemented by adding a new "draw" property to the cell object in the GridCanvas component. This property accepts a function that takes a canvas context as a parameter and can be used to draw custom graphics or shapes in the cell.