### PR TITLE
Disable context menu and allow right clicking

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -383,8 +383,6 @@ function initialize(element) {
                 context.state.options.onFiltersChange(getCombinedCells(context.state.options.filters, [{ ...cell, expression: newValue }]));
         } else if (column.type === 'DATA' && row.type === 'DATA') {
             context.state.options.onCellClick({ ...context.state.hoveredCell, ...eventProperties });
-            event.preventDefault(); 
-            event.stopPropagation();
         } else if (column.type === 'CUSTOM' || row.type === 'CUSTOM') {
             context.state.options.onCustomCellClick({ ...context.state.hoveredCell, ...eventProperties });
         } else if (column.type === 'HEADER' || row.type === 'HEADER') {
@@ -395,8 +393,9 @@ function initialize(element) {
     }
 
     context.addEventListener(element, 'contextmenu', (event) => {
-        event.preventDefault()
         onMouseClick(event)
+        event.preventDefault(); 
+        event.stopPropagation();
         return false
     })
     context.addEventListener(element, 'click', (event) => {

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -342,7 +342,8 @@ function initialize(element) {
         context.element.releasePointerCapture(event.pointerId);
     });
 
-    context.addEventListener(element, 'click', (event) => {
+    function onMouseClick(event)
+    {
         updateState(context);
 
         const cell = context.state.hoveredCell;
@@ -382,6 +383,8 @@ function initialize(element) {
                 context.state.options.onFiltersChange(getCombinedCells(context.state.options.filters, [{ ...cell, expression: newValue }]));
         } else if (column.type === 'DATA' && row.type === 'DATA') {
             context.state.options.onCellClick({ ...context.state.hoveredCell, ...eventProperties });
+            event.preventDefault(); 
+            event.stopPropagation();
         } else if (column.type === 'CUSTOM' || row.type === 'CUSTOM') {
             context.state.options.onCustomCellClick({ ...context.state.hoveredCell, ...eventProperties });
         } else if (column.type === 'HEADER' || row.type === 'HEADER') {
@@ -389,6 +392,15 @@ function initialize(element) {
             context.state.options.onSortByChange(newSortBy);
             context.state.options.onSelectedCellsChange([]);
         }
+    }
+
+    context.addEventListener(element, 'contextmenu', (event) => {
+        event.preventDefault()
+        onMouseClick(event)
+        return false
+    })
+    context.addEventListener(element, 'click', (event) => {
+        onMouseClick(event)
     });
 
     context.addEventListener(element, 'dblclick', (event) => {


### PR DESCRIPTION
Previously when right click the context menu would appear and right clicks wouldn't be registered by the `click` event listener.

This change adds a handler to the contextMenu opening, redirects that mousePointEvent to the click handler and prevents the context menu from being opened.

Have evaluated this locally.