### PR TITLE
Passing through font styling

### DIFF
--- a/dash/src/lib/components/DashSpreadGrid.jsx
+++ b/dash/src/lib/components/DashSpreadGrid.jsx
@@ -25,6 +25,8 @@ function useResolvedFormatting(formatting) {
                 mappedRule.value = eval(`(${context})=> (${rule.value})`);
             if ('text' in rule)
                 mappedRule.text = eval(`(${context}) => (${rule.text})`);
+            if ('font' in rule)
+                mappedRule.font = isString(rule.font) ? eval(`(${context}) => (${rule.font})`) : rule.font;
             if ('style' in rule)
                 mappedRule.style = isString(rule.style) ? eval(`(${context}) => (${rule.style})`) : rule.style;
             if ('padding' in rule)

--- a/dash/src/lib/components/DashSpreadGrid.jsx
+++ b/dash/src/lib/components/DashSpreadGrid.jsx
@@ -26,7 +26,7 @@ function useResolvedFormatting(formatting) {
             if ('text' in rule)
                 mappedRule.text = eval(`(${context}) => (${rule.text})`);
             if ('font' in rule)
-                mappedRule.font = isString(rule.font) ? eval(`(${context}) => (${rule.font})`) : rule.font;
+                mappedRule.font = eval(`(${context}) => (${rule.font})`);
             if ('style' in rule)
                 mappedRule.style = isString(rule.style) ? eval(`(${context}) => (${rule.style})`) : rule.style;
             if ('padding' in rule)

--- a/docs/src/pages/formatting/snippets/font/example.py
+++ b/docs/src/pages/formatting/snippets/font/example.py
@@ -6,7 +6,7 @@ app.layout = DashSpreadGrid(  # type: ignore
     ],
     formatting=[
         {
-            "font": "bold 14px Comic Sans MS",
+            "font": "'bold 14px Comic Sans MS'",
         }
     ],
 )


### PR DESCRIPTION
This aims to fix font styling that previously wasn't being applied. 

Example code:
```
import dash_spread_grid
from dash import Dash, callback, html, Input, Output, _dash_renderer, State
from dash.exceptions import PreventUpdate

_dash_renderer._set_react_version("18.2.0")

app = Dash(__name__)
app.layout = html.Div([
    dash_spread_grid.DashSpreadGrid(
        id='grid',
        data=[
            {"name": "John", "age": 25, "score": 100, "registered": True, "team": "red"},
            {"name": "Alice", "age": 24, "score": -70, "registered": False, "team": "blue"},
            {"name": "Bob", "age": 26, "score": 35, "registered": True, "team": "blue"},
            {"name": "Charlie", "age": 27, "score": 60, "registered": False, "team": "red"},
            {"name": "David", "age": 18, "score": 60, "registered": True, "team": "red"},
            {"name": "Eve", "age": 29, "score": 80, "registered": False, "team": "green"},
            {"name": "Frank", "age": 30, "score": 50, "registered": True, "team": "blue"}
        ],
        formatting=[
            {
                "column": {"id": "score"},
                "font": "value > 60 ? 'bold 8px Comic Sans MS' : 'bold 100px Times New Roman'"
            },
        ],
    )
])


if __name__ == '__main__':
    app.run_server(debug=True)
```